### PR TITLE
Update create-bundle to cache-aware CLI v0.5.0

### DIFF
--- a/.github/workflows/test-create-bundle.yml
+++ b/.github/workflows/test-create-bundle.yml
@@ -13,14 +13,18 @@ jobs:
           tag: "latest"
           platforms: "osx64,linux64,win64"
       - uses: actions/checkout@v4
-      - uses: advanced-security/codeql-bundle-action/create-bundle@v2
+      - name: Test create-bundle argument forwarding
+        run: bash tests/test-create-bundle.sh
+      - uses: ./create-bundle
         id: create-bundle
         with:
           bundle-path: ${{ steps.download-bundle.outputs.bundle-path }}
-          packs: "test/go-queries,test/go-customizations,test/java-queries,test/cpp-queries,test/javascript-queries" 
+          packs: "test/go-queries,test/go-customizations,test/java-queries,test/cpp-queries,test/javascript-queries"
           workspace: "${{ github.workspace }}/tests/codeql-workspace.yml"
           default-code-scanning-config: "${{ github.workspace }}/tests/code-scanning-config.yml"
           platforms: "osx64,linux64,win64"
+          threads: "2"
+          cache-dir: "${{ runner.temp }}/codeql-bundle-cache"
           debug: "true"
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-create-bundle.yml
+++ b/.github/workflows/test-create-bundle.yml
@@ -13,8 +13,10 @@ jobs:
           tag: "latest"
           platforms: "osx64,linux64,win64"
       - uses: actions/checkout@v4
-      - name: Test create-bundle argument forwarding
-        run: bash tests/test-create-bundle.sh
+      - name: Test bundle scripts
+        run: |
+          bash tests/test-create-bundle.sh
+          bash tests/test-run-locally.sh
       - uses: ./create-bundle
         id: create-bundle
         with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CodeQL bundle action
 
-This action retrofits an existing [CodeQL bundle](https://github.com/github/codeql-action/releases) with additional [CodeQL packs](https://codeql.github.com/docs/codeql-cli/creating-and-working-with-codeql-packs/) using the [CodeQL bundle CLI](https://github.com/rvermeulen/codeql-bundle)
+This action retrofits an existing [CodeQL bundle](https://github.com/github/codeql-action/releases) with additional [CodeQL packs](https://codeql.github.com/docs/codeql-cli/creating-and-working-with-codeql-packs/) using the [CodeQL bundle CLI](https://github.com/advanced-security/codeql-bundle).
 The bundle will be a single deployable artifact containing the CodeQL standard library, the CodeQL standard queries, and any other libraries or queries that are relevant.
 Additionally, the CodeQL standard library and standard queries can be customized to consider additional sources, sinks, data-flow/taint steps, sanitizers and barriers.
 
@@ -45,6 +45,20 @@ jobs:
           name: codeql-bundle.tar.gz
           path: ${{ steps.create-bundle.outputs.output-path }}
 ```
+
+### Cache and compilation controls
+
+The `create-bundle` action installs [CodeQL bundle CLI v0.5.0](https://github.com/advanced-security/codeql-bundle/releases/tag/v0.5.0) and supports its cache-aware bundle creation options:
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `threads` | CLI default | Number of threads to use when compiling queries |
+| `cache-dir` | CLI default | Directory used for downloaded bundles and compilation caches |
+| `cache-manifest` | CLI default | Path or URL of a supported bundle manifest |
+| `no-compilation-cache` | `false` | Do not resolve, download, or use published compilation caches |
+| `no-precompile` | `false` | Do not precompile the bundle |
+
+Leave `threads`, `cache-dir`, or `cache-manifest` unset to preserve the corresponding CLI default.
 
 The following Action workflow excerpt shows how a custom bundle can be used in a CodeQL analysis workflow.
 It assumes the custom bundle is available as a release, but any other location works as long as it is made
@@ -136,4 +150,4 @@ When providing multiple platforms the `output-path` output is a directory contai
 
 ## Limitations
 
-This Action uses the [CodeQL bundle CLI](https://github.com/rvermeulen/codeql-bundle) and inherits its limitations.
+This Action uses the [CodeQL bundle CLI](https://github.com/advanced-security/codeql-bundle) and inherits its limitations.

--- a/create-bundle/action.yml
+++ b/create-bundle/action.yml
@@ -19,6 +19,26 @@ inputs:
     description: A comma-separated list of platforms to build the bundle for, if supported by the bundle. Typically used with the generic bundle to build a specific platform bundle on a different runner architecture.
     required: false
     default: ""
+  threads:
+    description: Number of threads to use when compiling queries
+    required: false
+    default: ""
+  cache-dir:
+    description: Directory used for downloaded bundles and compilation caches
+    required: false
+    default: ""
+  cache-manifest:
+    description: Path or URL of a supported bundle manifest
+    required: false
+    default: ""
+  no-compilation-cache:
+    description: Do not resolve, download, or use published compilation caches
+    required: false
+    default: "false"
+  no-precompile:
+    description: Do not precompile the bundle
+    required: false
+    default: "false"
   debug:
     description: Enable debug logging, by setting this value to "true"
     required: false
@@ -35,8 +55,8 @@ runs:
         python-version: "3.11"
     - run: |
         echo "::group::Installing dependencies"
-        echo "Installing codeql-bundle v0.2.0"
-        python -m pip install https://github.com/advanced-security/codeql-bundle/releases/download/v0.2.0/codeql_bundle-0.2.0-py3-none-any.whl
+        echo "Installing codeql-bundle v0.5.0"
+        python -m pip install "https://github.com/advanced-security/codeql-bundle/releases/download/v0.5.0/codeql_bundle-0.5.0-py3-none-any.whl"
         echo "::endgroup::"
       shell: bash
     - id: create-bundle
@@ -47,41 +67,12 @@ runs:
         DEFAULT_CODE_SCANNING_CONFIG: ${{ inputs.default-code-scanning-config }}
         PLATFORMS: ${{ inputs.platforms }}
         RUNNER_TEMP: ${{ runner.temp }}
+        THREADS: ${{ inputs.threads }}
+        CACHE_DIR: ${{ inputs.cache-dir }}
+        CACHE_MANIFEST: ${{ inputs.cache-manifest }}
+        NO_COMPILATION_CACHE: ${{ inputs.no-compilation-cache }}
+        NO_PRECOMPILE: ${{ inputs.no-precompile }}
         DEBUG: ${{ inputs.debug }}
+        ACTION_PATH: ${{ github.action_path }}
       shell: bash
-      run: |
-        #!/bin/bash
-
-        set -e
-
-        echo "::group::Creating CodeQL bundle."
-        echo "Using bundle at ${BUNDLE_PATH}."
-        echo "Using workspace at ${WORKSPACE}."
-        output_path=${RUNNER_TEMP}/codeql-bundle.tar.gz
-        opts=()
-        opts+=("--bundle" "${BUNDLE_PATH}")
-        opts+=("--workspace" "${WORKSPACE}")
-        if [[ -n ${PLATFORMS} ]]; then
-            echo "Targetting the platforms ${PLATFORMS}."
-            for platform in $(echo $PLATFORMS | tr ',' ' '); do
-            opts+=("--platform" "${platform}")
-            done
-            # When building multiple bundles, the output path is the directory containing the bundles
-            output_path=${RUNNER_TEMP}/bundles
-            mkdir -p ${output_path}
-        fi
-        opts+=("--output" "${output_path}")
-        if [[ -n ${DEFAULT_CODE_SCANNING_CONFIG} ]]; then
-            echo "Using code scanning config at ${DEFAULT_CODE_SCANNING_CONFIG} as the default config."
-            opts+=("--code-scanning-config" "${DEFAULT_CODE_SCANNING_CONFIG}")
-        fi
-
-        if [[ ${DEBUG} -eq "true" ]]; then
-            opts+=("--log DEBUG")
-        fi
-
-
-        codeql-bundle ${opts[@]} $(echo ${PACKS} | tr ',' ' ')
-        echo "::endgroup::"
-
-        echo "output-path=${output_path}" >> $GITHUB_OUTPUT
+      run: bash "${ACTION_PATH}/create-bundle.sh"

--- a/create-bundle/create-bundle.sh
+++ b/create-bundle/create-bundle.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+trim_whitespace() {
+    local value="$1"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    printf '%s' "$value"
+}
+
+echo "::group::Creating CodeQL bundle."
+echo "Using bundle at ${BUNDLE_PATH}."
+echo "Using workspace at ${WORKSPACE}."
+
+output_path="${RUNNER_TEMP}/codeql-bundle.tar.gz"
+opts=(
+    "--bundle" "${BUNDLE_PATH}"
+    "--workspace" "${WORKSPACE}"
+)
+
+if [[ -n "${PLATFORMS}" ]]; then
+    echo "Targeting the platforms ${PLATFORMS}."
+    IFS=',' read -r -a platforms <<< "${PLATFORMS}"
+    for platform in "${platforms[@]}"; do
+        platform="$(trim_whitespace "${platform}")"
+        if [[ -n "${platform}" ]]; then
+            opts+=("--platform" "${platform}")
+        fi
+    done
+
+    output_path="${RUNNER_TEMP}/bundles"
+    mkdir -p "${output_path}"
+fi
+
+opts+=("--output" "${output_path}")
+
+if [[ -n "${DEFAULT_CODE_SCANNING_CONFIG}" ]]; then
+    echo "Using code scanning config at ${DEFAULT_CODE_SCANNING_CONFIG} as the default config."
+    opts+=("--code-scanning-config" "${DEFAULT_CODE_SCANNING_CONFIG}")
+fi
+
+if [[ -n "${THREADS:-}" ]]; then
+    opts+=("--threads" "${THREADS}")
+fi
+
+if [[ -n "${CACHE_DIR:-}" ]]; then
+    opts+=("--cache-dir" "${CACHE_DIR}")
+fi
+
+if [[ -n "${CACHE_MANIFEST:-}" ]]; then
+    opts+=("--cache-manifest" "${CACHE_MANIFEST}")
+fi
+
+if [[ "${NO_COMPILATION_CACHE:-false}" == "true" ]]; then
+    opts+=("--no-compilation-cache")
+fi
+
+if [[ "${NO_PRECOMPILE:-false}" == "true" ]]; then
+    opts+=("--no-precompile")
+fi
+
+if [[ "${DEBUG:-false}" == "true" ]]; then
+    opts+=("--log" "DEBUG")
+fi
+
+IFS=',' read -r -a requested_packs <<< "${PACKS}"
+packs=()
+for pack in "${requested_packs[@]}"; do
+    pack="$(trim_whitespace "${pack}")"
+    if [[ -n "${pack}" ]]; then
+        packs+=("${pack}")
+    fi
+done
+
+codeql-bundle "${opts[@]}" "${packs[@]}"
+echo "::endgroup::"
+
+printf 'output-path=%s\n' "${output_path}" >> "${GITHUB_OUTPUT}"

--- a/tests/run-locally.sh
+++ b/tests/run-locally.sh
@@ -1,19 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
-SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
-export RUNNER_TEMP=$(mktemp -d)
+set -euo pipefail
 
-trap "{ rm -r "${RUNNER_TEMP}" ; exit 1; }" SIGINT SIGTERM ERR
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+export RUNNER_TEMP
+RUNNER_TEMP=$(mktemp -d)
+trap 'rm -rf "${RUNNER_TEMP}"' EXIT
 
-echo "Runner temp: $RUNNER_TEMP"
-export GITHUB_OUTPUT=${RUNNER_TEMP}/github_output
-echo "GitHub output: $GITHUB_OUTPUT"
+echo "Runner temp: ${RUNNER_TEMP}"
+export GITHUB_OUTPUT="${RUNNER_TEMP}/github_output"
+echo "GitHub output: ${GITHUB_OUTPUT}"
 
 export PLATFORMS="osx64,linux64,win64"
 export TAG="latest"
 
-bash $SCRIPT_DIR/../download-bundle/download-bundle.sh
+bash "${SCRIPT_DIR}/../download-bundle/download-bundle.sh"
 
 bundle_path=""
 while IFS='=' read -r key value; do
@@ -21,25 +22,29 @@ while IFS='=' read -r key value; do
         # The output path is the second value
         bundle_path=$value
     fi
-done < $GITHUB_OUTPUT
+done < "${GITHUB_OUTPUT}"
 
-if [[ -z ${bundle_path} ]]; then
+if [[ -z "${bundle_path}" ]]; then
     echo "Failed to download bundle!"
     exit 1
 fi
 
-export BUNDLE_PATH=${bundle_path}
-export PACKS="test/go-queries,test/go-customizations,test/java-queries,test/cpp-queries,test/javascript-queries" 
+export BUNDLE_PATH="${bundle_path}"
+export PACKS="test/go-queries,test/go-customizations,test/java-queries,test/cpp-queries,test/javascript-queries"
 export WORKSPACE="${SCRIPT_DIR}/codeql-workspace.yml"
 export DEFAULT_CODE_SCANNING_CONFIG="${SCRIPT_DIR}/code-scanning-config.yml"
 
+PYTHON="${PYTHON:-python3}"
+if ! "${PYTHON}" -c 'import sys; raise SystemExit(sys.version_info < (3, 11))'; then
+    echo "codeql-bundle v0.5.0 requires Python 3.11 or later" >&2
+    exit 1
+fi
+"${PYTHON}" -m venv "${RUNNER_TEMP}/venv"
+source "${RUNNER_TEMP}/venv/bin/activate"
 
-python3 -mvenv $RUNNER_TEMP/venv
-source $RUNNER_TEMP/venv/bin/activate
+python -m pip install "https://github.com/advanced-security/codeql-bundle/releases/download/v0.5.0/codeql_bundle-0.5.0-py3-none-any.whl"
 
-pip install https://github.com/rvermeulen/codeql-bundle/releases/download/v0.2.0/codeql_bundle-0.2.0-py3-none-any.whl
-
-bash $SCRIPT_DIR/../create-bundle/create-bundle.sh
+bash "${SCRIPT_DIR}/../create-bundle/create-bundle.sh"
 
 # Read the output path from the GitHub output file and split each line by the '=' character
 output_path=""
@@ -48,12 +53,13 @@ while IFS='=' read -r key value; do
         # The output path is the second value
         output_path=$value
     fi
-done < $GITHUB_OUTPUT
+done < "${GITHUB_OUTPUT}"
 
-if [[ -n ${output_path} ]]; then
-    tar cf ${SCRIPT_DIR}/codeql-bundles.tar.gz -C ${output_path} .
+if [[ -n "${output_path}" ]]; then
+    tar -cf "${SCRIPT_DIR}/codeql-bundles.tar.gz" -C "${output_path}" .
 else
     echo "Failed to find output path in GitHub output file"
+    exit 1
 fi
 
-rm -r "${RUNNER_TEMP}"
+echo "Created bundles at ${output_path}"

--- a/tests/run-locally.sh
+++ b/tests/run-locally.sh
@@ -18,8 +18,7 @@ bash "${SCRIPT_DIR}/../download-bundle/download-bundle.sh"
 
 bundle_path=""
 while IFS='=' read -r key value; do
-    if [[ $key == "output-path" ]]; then
-        # The output path is the second value
+    if [[ $key == "bundle-path" ]]; then
         bundle_path=$value
     fi
 done < "${GITHUB_OUTPUT}"

--- a/tests/test-create-bundle.sh
+++ b/tests/test-create-bundle.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+ROOT=$(cd -- "${SCRIPT_DIR}/.." && pwd)
+ACTION="${ROOT}/create-bundle/action.yml"
+CREATE_BUNDLE="${ROOT}/create-bundle/create-bundle.sh"
+
+temp_dir=$(mktemp -d)
+trap 'rm -rf "${temp_dir}"' EXIT
+
+mkdir -p "${temp_dir}/bin"
+cat > "${temp_dir}/bin/codeql-bundle" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\0' "$@" > "${CAPTURE_ARGS}"
+EOF
+chmod +x "${temp_dir}/bin/codeql-bundle"
+
+assert_action_contains() {
+    if ! grep -Fq -- "$1" "${ACTION}"; then
+        echo "Expected action.yml to contain: $1" >&2
+        exit 1
+    fi
+}
+
+assert_args() {
+    local capture_path="$1"
+    shift
+    local expected=("$@")
+    local actual=()
+    local arg
+    while IFS= read -r -d '' arg; do
+        actual+=("${arg}")
+    done < "${capture_path}"
+
+    if [[ "${#actual[@]}" -ne "${#expected[@]}" ]]; then
+        echo "Expected ${#expected[@]} arguments, got ${#actual[@]}" >&2
+        printf 'Actual argument: <%s>\n' "${actual[@]}" >&2
+        exit 1
+    fi
+
+    local index
+    for ((index = 0; index < ${#expected[@]}; index++)); do
+        if [[ "${actual[index]}" != "${expected[index]}" ]]; then
+            echo "Argument ${index}: expected <${expected[index]}>, got <${actual[index]}>" >&2
+            exit 1
+        fi
+    done
+}
+
+assert_output() {
+    local actual
+    actual=$(< "$1")
+    if [[ "${actual}" != "output-path=$2" ]]; then
+        echo "Expected output-path=$2, got ${actual}" >&2
+        exit 1
+    fi
+}
+
+run_default_case() {
+    local case_dir="${temp_dir}/default case"
+    mkdir -p "${case_dir}"
+    export CAPTURE_ARGS="${case_dir}/args"
+    export GITHUB_OUTPUT="${case_dir}/github-output"
+    export RUNNER_TEMP="${case_dir}/runner temp"
+    export BUNDLE_PATH="${case_dir}/source bundle.tar.gz"
+    export PACKS="test/pack-one,test/pack-two"
+    export WORKSPACE="${case_dir}/workspace path"
+    export DEFAULT_CODE_SCANNING_CONFIG=""
+    export PLATFORMS=""
+    export THREADS=""
+    export CACHE_DIR=""
+    export CACHE_MANIFEST=""
+    export NO_COMPILATION_CACHE="false"
+    export NO_PRECOMPILE="false"
+    export DEBUG="false"
+
+    bash "${CREATE_BUNDLE}"
+
+    local output_path="${RUNNER_TEMP}/codeql-bundle.tar.gz"
+    assert_args "${CAPTURE_ARGS}" \
+        "--bundle" "${BUNDLE_PATH}" \
+        "--workspace" "${WORKSPACE}" \
+        "--output" "${output_path}" \
+        "test/pack-one" "test/pack-two"
+    assert_output "${GITHUB_OUTPUT}" "${output_path}"
+}
+
+run_options_case() {
+    local case_dir="${temp_dir}/options case"
+    mkdir -p "${case_dir}"
+    export CAPTURE_ARGS="${case_dir}/args"
+    export GITHUB_OUTPUT="${case_dir}/github-output"
+    export RUNNER_TEMP="${case_dir}/runner temp"
+    export BUNDLE_PATH="${case_dir}/source bundle.tar.gz"
+    export PACKS="test/pack-one, test/pack-two"
+    export WORKSPACE="${case_dir}/workspace path"
+    export DEFAULT_CODE_SCANNING_CONFIG="${case_dir}/code scanning.yml"
+    export PLATFORMS="osx64, linux64"
+    export THREADS="6"
+    export CACHE_DIR="${case_dir}/cache directory"
+    export CACHE_MANIFEST="https://example.test/catalog.json?channel=stable&format=1"
+    export NO_COMPILATION_CACHE="true"
+    export NO_PRECOMPILE="true"
+    export DEBUG="true"
+
+    bash "${CREATE_BUNDLE}"
+
+    local output_path="${RUNNER_TEMP}/bundles"
+    assert_args "${CAPTURE_ARGS}" \
+        "--bundle" "${BUNDLE_PATH}" \
+        "--workspace" "${WORKSPACE}" \
+        "--platform" "osx64" \
+        "--platform" "linux64" \
+        "--output" "${output_path}" \
+        "--code-scanning-config" "${DEFAULT_CODE_SCANNING_CONFIG}" \
+        "--threads" "${THREADS}" \
+        "--cache-dir" "${CACHE_DIR}" \
+        "--cache-manifest" "${CACHE_MANIFEST}" \
+        "--no-compilation-cache" \
+        "--no-precompile" \
+        "--log" "DEBUG" \
+        "test/pack-one" "test/pack-two"
+    assert_output "${GITHUB_OUTPUT}" "${output_path}"
+    [[ -d "${output_path}" ]]
+}
+
+export PATH="${temp_dir}/bin:${PATH}"
+bash -n "${CREATE_BUNDLE}"
+assert_action_contains "https://github.com/advanced-security/codeql-bundle/releases/download/v0.5.0/codeql_bundle-0.5.0-py3-none-any.whl"
+assert_action_contains 'THREADS: ${{ inputs.threads }}'
+assert_action_contains 'CACHE_DIR: ${{ inputs.cache-dir }}'
+assert_action_contains 'CACHE_MANIFEST: ${{ inputs.cache-manifest }}'
+assert_action_contains 'NO_COMPILATION_CACHE: ${{ inputs.no-compilation-cache }}'
+assert_action_contains 'NO_PRECOMPILE: ${{ inputs.no-precompile }}'
+assert_action_contains 'ACTION_PATH: ${{ github.action_path }}'
+run_default_case
+run_options_case
+
+echo "create-bundle action tests passed"

--- a/tests/test-run-locally.sh
+++ b/tests/test-run-locally.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+temp_dir=$(mktemp -d)
+trap 'rm -rf "${temp_dir}"' EXIT
+
+fixture_root="${temp_dir}/fixture"
+mkdir -p \
+    "${fixture_root}/tests" \
+    "${fixture_root}/download-bundle" \
+    "${fixture_root}/create-bundle" \
+    "${temp_dir}/bin"
+
+cp "${SCRIPT_DIR}/run-locally.sh" "${fixture_root}/tests/run-locally.sh"
+
+cat > "${fixture_root}/download-bundle/download-bundle.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+bundle_path="${RUNNER_TEMP}/downloaded bundle.tar.gz"
+: > "${bundle_path}"
+printf 'bundle-path=%s\n' "${bundle_path}" >> "${GITHUB_OUTPUT}"
+EOF
+
+cat > "${fixture_root}/create-bundle/create-bundle.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+expected_bundle_path="${RUNNER_TEMP}/downloaded bundle.tar.gz"
+if [[ "${BUNDLE_PATH}" != "${expected_bundle_path}" ]]; then
+    echo "Expected BUNDLE_PATH=${expected_bundle_path}, got ${BUNDLE_PATH}" >&2
+    exit 1
+fi
+
+output_path="${RUNNER_TEMP}/bundles"
+mkdir -p "${output_path}"
+: > "${output_path}/codeql-bundle-linux64.tar.gz"
+printf 'output-path=%s\n' "${output_path}" >> "${GITHUB_OUTPUT}"
+EOF
+
+cat > "${temp_dir}/bin/python3" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "-c" ]]; then
+    exit 0
+fi
+
+if [[ "${1:-}" == "-m" && "${2:-}" == "venv" ]]; then
+    mkdir -p "$3/bin"
+    : > "$3/bin/activate"
+    exit 0
+fi
+
+if [[ "${1:-}" == "-m" && "${2:-}" == "pip" ]]; then
+    exit 0
+fi
+
+echo "Unexpected Python invocation: $*" >&2
+exit 1
+EOF
+
+chmod +x \
+    "${fixture_root}/download-bundle/download-bundle.sh" \
+    "${fixture_root}/create-bundle/create-bundle.sh" \
+    "${temp_dir}/bin/python3"
+ln -s "${temp_dir}/bin/python3" "${temp_dir}/bin/python"
+
+PATH="${temp_dir}/bin:${PATH}" \
+    PYTHON="${temp_dir}/bin/python3" \
+    bash "${fixture_root}/tests/run-locally.sh"
+
+archive="${fixture_root}/tests/codeql-bundles.tar.gz"
+if [[ ! -f "${archive}" ]]; then
+    echo "Expected local runner to create ${archive}" >&2
+    exit 1
+fi
+
+if ! tar -tf "${archive}" | grep -Fxq './codeql-bundle-linux64.tar.gz'; then
+    echo "Expected generated archive to contain the mocked bundle" >&2
+    exit 1
+fi
+
+echo "local runner test passed"


### PR DESCRIPTION
## Summary

- pin the published `codeql-bundle` v0.5.0 wheel
- expose the released `threads`, `cache-dir`, `cache-manifest`, `no-compilation-cache`, and `no-precompile` inputs while preserving existing defaults
- construct CLI arguments safely as Bash arrays, including forwarding `--log` and `DEBUG` as separate arguments
- add mock-backed argument forwarding tests and update the local/manual workflow coverage
- document v0.5.0 cache and compilation controls

This intentionally does not expose `--ram` or `--compression-level`, which are not part of v0.5.0.

## Validation

- `bash tests/test-create-bundle.sh`
- `bash -n create-bundle/create-bundle.sh tests/test-create-bundle.sh tests/run-locally.sh`
- Actionlint v1.7.7 on `.github/workflows/test-create-bundle.yml`
- parsed `create-bundle/action.yml` and verified input defaults
- installed/inspected the published v0.5.0 wheel and verified all five forwarded options exist while `--ram` and `--compression-level` do not